### PR TITLE
fix(inbound): unwrap message/rfc822 "forward as attachment" emails

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "pdf-parse": "^1.1.1",
     "pdfjs-dist": "^5.6.205",
     "pg": "^8.16.3",
+    "postal-mime": "^2.7.4",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-email": "^5.2.1",

--- a/src/app/api/admin/replay-inbound/route.ts
+++ b/src/app/api/admin/replay-inbound/route.ts
@@ -36,6 +36,7 @@ import { processClientDocument } from "@/lib/client-document-processor";
 import { getClientParser, getInvoiceParser } from "@/lib/client-parsers";
 import { matchFranchiseeName } from "@/lib/franchisee-matcher";
 import { isWoltEzcountFileB } from "@/lib/client-parsers/wolt-parser";
+import { isRfc822Attachment, unwrapRfc822 } from "@/lib/email/unwrap-rfc822";
 import type { Franchisee } from "@/db/schema";
 
 const BODY_BASED_CLIENTS = new Set(["CIBUS"]);
@@ -351,7 +352,109 @@ export async function POST(request: NextRequest) {
           }
         }
       } else {
-        const docAtts = email.attachments.filter(
+        // Unwrap "Forward as attachment" emails (message/rfc822) first —
+        // mirrors email-inbound/route.ts. Each wrapped .eml yields inner
+        // PDF/Excel documents and/or an inner body with download links,
+        // classified by the INNER subject (the outer forward may be blank).
+        const rfc822Atts = email.attachments.filter(isRfc822Attachment);
+        const directAtts = email.attachments.filter(
+          (a) => !isRfc822Attachment(a),
+        );
+
+        for (let e = 0; e < rfc822Atts.length; e++) {
+          const emlBuffer = await downloadAttachment(rfc822Atts[e].downloadUrl);
+          if (!emlBuffer) continue;
+          let innerType: "client_report" | "commission_invoice" = documentType;
+          let extracted: Array<{ buffer: Buffer; fileName: string }> = [];
+          let innerBody = "";
+          try {
+            const unwrapped = await unwrapRfc822(emlBuffer);
+            innerType = detectDocumentType(unwrapped.subject);
+            extracted = unwrapped.pdfFiles;
+            innerBody = `${unwrapped.html}\n${unwrapped.text}`;
+          } catch {
+            continue;
+          }
+
+          // Inner PDF/Excel documents.
+          for (let j = 0; j < extracted.length; j++) {
+            const f = extracted[j];
+            const fr = await resolveFranchisee(
+              f.buffer,
+              "application/pdf",
+              identifiedClient.parserCode,
+              email.subject,
+              allFranchisees,
+              f.fileName,
+              innerType,
+            );
+            if (!fr) {
+              trace.franchiseeResolveFailures!.push(f.fileName);
+              continue;
+            }
+            const r = await processClientDocument({
+              buffer: f.buffer,
+              fileName: f.fileName,
+              mimeType: "application/pdf",
+              clientId: identifiedClient.clientId,
+              parserCode: identifiedClient.parserCode,
+              franchiseeId: fr.franchiseeId,
+              periodMonth: period.month,
+              periodYear: period.year,
+              documentType: innerType,
+              source: "gmail_fetch",
+              gmailMessageId: `${emailId}#eml${e}_${j}`,
+            });
+            if (r.skippedDuplicate) duplicatesSkipped++;
+            else if (r.success) documentsCreated++;
+            else
+              trace.processFailures!.push(
+                `${f.fileName}: ${r.error ?? "unknown"}`,
+              );
+          }
+
+          // Inner body download links (link-based invoices).
+          if (innerBody.trim()) {
+            const downloaded = await extractAndDownloadLinks(innerBody);
+            for (let i = 0; i < downloaded.length; i++) {
+              const f = downloaded[i];
+              const fr = await resolveFranchisee(
+                f.buffer,
+                "application/pdf",
+                identifiedClient.parserCode,
+                email.subject,
+                allFranchisees,
+                f.fileName,
+                innerType,
+              );
+              if (!fr) {
+                trace.franchiseeResolveFailures!.push(f.fileName);
+                continue;
+              }
+              const r = await processClientDocument({
+                buffer: f.buffer,
+                fileName: f.fileName,
+                mimeType: "application/pdf",
+                clientId: identifiedClient.clientId,
+                parserCode: identifiedClient.parserCode,
+                franchiseeId: fr.franchiseeId,
+                periodMonth: period.month,
+                periodYear: period.year,
+                documentType: innerType,
+                source: "gmail_fetch",
+                gmailMessageId: `${emailId}#emldl${e}_${i}`,
+              });
+              if (r.skippedDuplicate) duplicatesSkipped++;
+              else if (r.success) documentsCreated++;
+              else
+                trace.processFailures!.push(
+                  `${f.fileName}: ${r.error ?? "unknown"}`,
+                );
+            }
+          }
+        }
+
+        const docAtts = directAtts.filter(
           (a) =>
             a.contentType === "application/pdf" ||
             a.contentType ===

--- a/src/app/api/clients/email-inbound/route.ts
+++ b/src/app/api/clients/email-inbound/route.ts
@@ -48,6 +48,7 @@ import {
   isCibusDailyReport,
   isHaatMonthlyReport,
 } from "@/lib/email/classify-document-type";
+import { isRfc822Attachment, unwrapRfc822 } from "@/lib/email/unwrap-rfc822";
 import { findOperatingBrand } from "@/lib/franchisee-parent-map";
 import { detectRecipientClientCodeFromPdf } from "@/lib/email/detect-invoice-recipient";
 import { database } from "@/db";
@@ -568,8 +569,73 @@ export async function POST(request: NextRequest) {
           .join(", ")}`
       );
 
-      // Filter to PDF/Excel attachments only — skip inline images (logo, icons)
-      const documentAttachments = email.attachments.filter(
+      // ── Unwrap "Forward as attachment" emails (message/rfc822) ──
+      // Outlook wraps each forwarded email as a message/rfc822 attachment
+      // instead of carrying the original PDF/link. Those are not PDFs, so the
+      // PDF filter below would drop them all and the email would fail with
+      // "no attachments / no links" (real incident 2026-06-15: 3 March Tenbis
+      // commission invoices forwarded by hadas@latableg.com). We download each
+      // wrapped .eml, extract its inner PDF/Excel documents AND its inner body
+      // (so the link-download path can recover link-based invoices), and
+      // classify each by the INNER subject — the outer forward often has an
+      // empty subject.
+      const rfc822Attachments = email.attachments.filter(isRfc822Attachment);
+      const directAttachments = email.attachments.filter(
+        (a) => !isRfc822Attachment(a),
+      );
+
+      const extractedFiles: Array<{
+        buffer: Buffer;
+        fileName: string;
+        documentType: "client_report" | "commission_invoice";
+      }> = [];
+      // Inner email bodies to scan for download links, each with the document
+      // type inferred from its own subject.
+      const innerLinkSources: Array<{
+        body: string;
+        keyPrefix: string;
+        documentType: "client_report" | "commission_invoice";
+      }> = [];
+
+      for (let e = 0; e < rfc822Attachments.length; e++) {
+        const eml = rfc822Attachments[e];
+        const emlBuffer = await downloadAttachment(eml.downloadUrl);
+        if (!emlBuffer) {
+          errorCount++;
+          errorDetails.push(`לא ניתן להוריד מייל מצורף: ${eml.filename}`);
+          continue;
+        }
+        try {
+          const unwrapped = await unwrapRfc822(emlBuffer);
+          const innerType = detectDocumentType(
+            unwrapped.subject,
+            unwrapped.html || unwrapped.text || undefined,
+          );
+          for (const f of unwrapped.pdfFiles) {
+            extractedFiles.push({ ...f, documentType: innerType });
+          }
+          const innerBody = `${unwrapped.html}\n${unwrapped.text}`;
+          if (innerBody.trim()) {
+            innerLinkSources.push({
+              body: innerBody,
+              keyPrefix: `emldl${e}_`,
+              documentType: innerType,
+            });
+          }
+          console.log(
+            `[email-inbound] ${identifiedClient.clientCode}: unwrapped forwarded email "${eml.filename}" → subject="${unwrapped.subject}" type=${innerType}, ${unwrapped.pdfFiles.length} document(s)`,
+          );
+        } catch (err) {
+          errorCount++;
+          errorDetails.push(
+            `כשל בפענוח מייל מצורף "${eml.filename}": ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }
+
+      // Filter direct attachments to PDF/Excel only — skip inline images
+      // (logo, icons). rfc822 wrappers are handled above, not here.
+      const documentAttachments = directAttachments.filter(
         (a) =>
           a.contentType === "application/pdf" ||
           a.contentType === "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" ||
@@ -579,115 +645,104 @@ export async function POST(request: NextRequest) {
           a.filename.endsWith(".xls")
       );
 
-      diagnostics.filteredAttachmentCount = documentAttachments.length;
+      // Honest count: direct documents + PDFs extracted from forwarded emails.
+      diagnostics.filteredAttachmentCount =
+        documentAttachments.length + extractedFiles.length;
 
-      // If no document attachments, try to extract download links from email body
-      if (documentAttachments.length === 0) {
-        const downloadedFiles = await extractAndDownloadLinks(
-          email.html || email.text || "",
-          identifiedClient.clientCode
+      // Shared context + counter merge for buffer-file processing (extracted
+      // PDFs and link downloads both flow through processBufferFile).
+      const bufferCtx: BufferFileContext = {
+        identifiedClient,
+        subject,
+        from,
+        emailReceivedAt: email.createdAt ? new Date(email.createdAt) : null,
+        allFranchisees: allFranchisees as Franchisee[],
+        inactiveFranchisees: inactiveFranchisees as Franchisee[],
+        period,
+        syncLogId: syncLog.id,
+      };
+      const mergeOutcome = (o: BufferFileOutcome) => {
+        documentsCreated += o.created;
+        duplicatesSkipped += o.duplicate;
+        errorCount += o.errorCount;
+        errorDetails.push(...o.errorDetails);
+      };
+
+      // Process PDFs extracted from forwarded (message/rfc822) emails.
+      for (let j = 0; j < extractedFiles.length; j++) {
+        const f = extractedFiles[j];
+        mergeOutcome(
+          await processBufferFile(
+            {
+              buffer: f.buffer,
+              fileName: f.fileName,
+              documentType: f.documentType,
+              dedupKey: `${email_id}#eml${j}`,
+            },
+            bufferCtx,
+          ),
         );
+      }
 
-        if (downloadedFiles.length === 0) {
-          const msg = `מייל ${email_id} ללא קבצים מצורפים ולא נמצאו לינקים להורדה`;
-          errorCount++;
-          errorDetails.push(msg);
+      // Link-download path. Scan the OUTER body only when there are no direct
+      // attachments (existing behavior for Mandrill/inline-link 10bis cover
+      // emails), and ALWAYS scan the inner forwarded bodies when present
+      // (link-based invoices forwarded as attachments).
+      const linkSources: Array<{
+        body: string;
+        keyPrefix: string;
+        documentType: "client_report" | "commission_invoice";
+      }> = [];
+      if (documentAttachments.length === 0) {
+        // Keep the historical `#dl{i}` key prefix so re-deliveries stay
+        // idempotent with already-processed cover emails.
+        linkSources.push({
+          body: email.html || email.text || "",
+          keyPrefix: "dl",
+          documentType,
+        });
+      }
+      linkSources.push(...innerLinkSources);
 
-          // Capture body excerpt so we can see what the email actually
-          // contained without going to Resend or the backup mailbox.
-          const body = email.html || email.text || "";
-          if (body) {
-            diagnostics.bodyExcerpt = body.length > 8000 ? body.slice(0, 8000) : body;
-          }
-        }
-
+      let downloadedLinkCount = 0;
+      for (const src of linkSources) {
+        const downloadedFiles = await extractAndDownloadLinks(
+          src.body,
+          identifiedClient.clientCode,
+        );
+        downloadedLinkCount += downloadedFiles.length;
         for (let i = 0; i < downloadedFiles.length; i++) {
           const file = downloadedFiles[i];
-          // Re-route by the invoice's actual recipient ("לכבוד") — ezcount
-          // "[העתק]" copies arrive on the MISHLOCHA channel even when the
-          // franchisee issued the invoice to Haat (one ezcount sequence
-          // serves both clients).
-          const fileClient = await resolveFileClient(
-            identifiedClient,
-            file.buffer,
-            documentType,
-            file.fileName,
-            errorDetails,
+          mergeOutcome(
+            await processBufferFile(
+              {
+                buffer: file.buffer,
+                fileName: file.fileName,
+                documentType: src.documentType,
+                dedupKey: `${email_id}#${src.keyPrefix}${i}`,
+              },
+              bufferCtx,
+            ),
           );
-          const franchiseeMatch = await resolveFranchisee(
-            file.buffer,
-            "application/pdf",
-            fileClient.parserCode,
-            subject,
-            allFranchisees as Franchisee[],
-            file.fileName,
-            documentType,
-            inactiveFranchisees as Franchisee[],
-          );
+        }
+      }
 
-          if (isInactiveFranchiseeSkip(franchiseeMatch)) {
-            duplicatesSkipped++;
-            errorDetails.push(
-              `דולג: לינק לזכיין סגור "${franchiseeMatch.inactiveFranchiseeName}" (${file.fileName})`,
-            );
-            continue;
-          }
+      // Nothing found across ANY channel (direct docs, extracted forwarded
+      // docs, link downloads) → record the failure + body excerpt.
+      if (
+        documentAttachments.length === 0 &&
+        extractedFiles.length === 0 &&
+        downloadedLinkCount === 0
+      ) {
+        const msg = `מייל ${email_id} ללא קבצים מצורפים ולא נמצאו לינקים להורדה`;
+        errorCount++;
+        errorDetails.push(msg);
 
-          let dlResult: ProcessClientDocumentResult | null = null;
-          if (!franchiseeMatch.ok) {
-            errorCount++;
-            errorDetails.push(formatResolveFailure(franchiseeMatch, subject));
-          } else {
-            dlResult = await processClientDocument({
-              buffer: file.buffer,
-              fileName: file.fileName,
-              mimeType: "application/pdf",
-              clientId: fileClient.clientId,
-              parserCode: fileClient.parserCode,
-              franchiseeId: franchiseeMatch.franchiseeId,
-              periodMonth: period.month,
-              periodYear: period.year,
-              documentType,
-              source: "gmail_fetch",
-              // CRITICAL: gmail_message_id has a UNIQUE index. When a single
-              // email yields multiple downloaded files (e.g. multiple ezcount
-              // links), every file must use a DISTINCT key — otherwise the
-              // 2nd+ files are silently rejected as duplicates. Append the
-              // index to keep the prefix `email_id#` stable and searchable.
-              gmailMessageId: `${email_id}#dl${i}`,
-            });
-
-            if (dlResult.skippedDuplicate) {
-              duplicatesSkipped++;
-            } else if (dlResult.success) {
-              documentsCreated++;
-            } else {
-              errorCount++;
-              errorDetails.push(
-                `${file.fileName}: ${dlResult.error ?? "שגיאה בעיבוד"}`
-              );
-            }
-          }
-
-          await recordInboundReviewOutcome({
-            syncLogId: syncLog.id,
-            emailId: `${email_id}#dl${i}`,
-            emailSubject: subject,
-            emailFrom: from,
-            emailReceivedAt: email.createdAt ? new Date(email.createdAt) : null,
-            clientId: fileClient.clientId,
-            clientCode: fileClient.clientCode,
-            documentType,
-            franchiseeMatch,
-            processResult: dlResult,
-            fileContext: {
-              buffer: file.buffer,
-              fileName: file.fileName,
-              mimeType: "application/pdf",
-            },
-            periodMonth: period.month,
-            periodYear: period.year,
-          });
+        // Capture body excerpt so we can see what the email actually
+        // contained without going to Resend or the backup mailbox.
+        const body = email.html || email.text || "";
+        if (body) {
+          diagnostics.bodyExcerpt = body.length > 8000 ? body.slice(0, 8000) : body;
         }
       }
 
@@ -1380,6 +1435,134 @@ async function recordInboundReviewOutcome(args: {
       err,
     );
   }
+}
+
+/** Per-channel counters returned by processBufferFile, merged by the caller. */
+interface BufferFileOutcome {
+  created: number;
+  duplicate: number;
+  errorCount: number;
+  errorDetails: string[];
+}
+
+/** Shared email-level context for processing already-downloaded PDF buffers. */
+interface BufferFileContext {
+  identifiedClient: FileClientIdentity;
+  subject: string;
+  from: string;
+  emailReceivedAt: Date | null;
+  allFranchisees: Franchisee[];
+  inactiveFranchisees: Franchisee[];
+  period: { month: number; year: number };
+  syncLogId: string;
+}
+
+/**
+ * Process one already-downloaded PDF buffer through the full
+ * resolve→commit→record pipeline. Shared by (a) PDFs extracted from forwarded
+ * message/rfc822 attachments and (b) link-downloaded files.
+ *
+ * Each call MUST pass a DISTINCT `dedupKey`: gmail_message_id has a UNIQUE
+ * index, so reusing a key silently rejects the 2nd+ file as a duplicate.
+ * Returns counter deltas; never throws — failures are folded into the outcome.
+ */
+async function processBufferFile(
+  file: {
+    buffer: Buffer;
+    fileName: string;
+    dedupKey: string;
+    documentType: "client_report" | "commission_invoice";
+  },
+  ctx: BufferFileContext,
+): Promise<BufferFileOutcome> {
+  const outcome: BufferFileOutcome = {
+    created: 0,
+    duplicate: 0,
+    errorCount: 0,
+    errorDetails: [],
+  };
+
+  // Re-route by the invoice's actual recipient ("לכבוד") — ezcount "[העתק]"
+  // copies arrive on the MISHLOCHA channel even when the franchisee issued the
+  // invoice to Haat (one ezcount sequence serves both clients).
+  const fileClient = await resolveFileClient(
+    ctx.identifiedClient,
+    file.buffer,
+    file.documentType,
+    file.fileName,
+    outcome.errorDetails,
+  );
+  const franchiseeMatch = await resolveFranchisee(
+    file.buffer,
+    "application/pdf",
+    fileClient.parserCode,
+    ctx.subject,
+    ctx.allFranchisees,
+    file.fileName,
+    file.documentType,
+    ctx.inactiveFranchisees,
+  );
+
+  if (isInactiveFranchiseeSkip(franchiseeMatch)) {
+    outcome.duplicate++;
+    outcome.errorDetails.push(
+      `דולג: "${file.fileName}" לזכיין סגור "${franchiseeMatch.inactiveFranchiseeName}"`,
+    );
+    return outcome;
+  }
+
+  let result: ProcessClientDocumentResult | null = null;
+  if (!franchiseeMatch.ok) {
+    outcome.errorCount++;
+    outcome.errorDetails.push(formatResolveFailure(franchiseeMatch, ctx.subject));
+  } else {
+    result = await processClientDocument({
+      buffer: file.buffer,
+      fileName: file.fileName,
+      mimeType: "application/pdf",
+      clientId: fileClient.clientId,
+      parserCode: fileClient.parserCode,
+      franchiseeId: franchiseeMatch.franchiseeId,
+      periodMonth: ctx.period.month,
+      periodYear: ctx.period.year,
+      documentType: file.documentType,
+      source: "gmail_fetch",
+      gmailMessageId: file.dedupKey,
+    });
+
+    if (result.skippedDuplicate) {
+      outcome.duplicate++;
+    } else if (result.success) {
+      outcome.created++;
+    } else {
+      outcome.errorCount++;
+      outcome.errorDetails.push(
+        `${file.fileName}: ${result.error ?? "שגיאה בעיבוד"}`,
+      );
+    }
+  }
+
+  await recordInboundReviewOutcome({
+    syncLogId: ctx.syncLogId,
+    emailId: file.dedupKey,
+    emailSubject: ctx.subject,
+    emailFrom: ctx.from,
+    emailReceivedAt: ctx.emailReceivedAt,
+    clientId: fileClient.clientId,
+    clientCode: fileClient.clientCode,
+    documentType: file.documentType,
+    franchiseeMatch,
+    processResult: result,
+    fileContext: {
+      buffer: file.buffer,
+      fileName: file.fileName,
+      mimeType: "application/pdf",
+    },
+    periodMonth: ctx.period.month,
+    periodYear: ctx.period.year,
+  });
+
+  return outcome;
 }
 
 function formatResolveFailure(

--- a/src/lib/email/__tests__/unwrap-rfc822.test.ts
+++ b/src/lib/email/__tests__/unwrap-rfc822.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import { isRfc822Attachment, unwrapRfc822 } from "../unwrap-rfc822";
+
+/** Encode a (possibly Hebrew) header value as a UTF-8 base64 encoded-word. */
+function encodeWord(value: string): string {
+  return `=?UTF-8?B?${Buffer.from(value, "utf8").toString("base64")}?=`;
+}
+
+/** Build a raw RFC822 message with an optional base64 attachment. */
+function buildEml(opts: {
+  subject: string;
+  html: string;
+  attachment?: { filename: string; contentType: string; content: Buffer };
+}): Buffer {
+  const boundary = "BOUND123";
+  const lines: string[] = [
+    `Subject: ${encodeWord(opts.subject)}`,
+    "From: service@10bis.co.il",
+    "To: hadas@latableg.com",
+    "MIME-Version: 1.0",
+    `Content-Type: multipart/mixed; boundary="${boundary}"`,
+    "",
+    `--${boundary}`,
+    "Content-Type: text/html; charset=utf-8",
+    "Content-Transfer-Encoding: base64",
+    "",
+    Buffer.from(opts.html, "utf8").toString("base64"),
+  ];
+  if (opts.attachment) {
+    const { filename, contentType, content } = opts.attachment;
+    lines.push(
+      `--${boundary}`,
+      `Content-Type: ${contentType}; name="${filename}"`,
+      `Content-Disposition: attachment; filename="${filename}"`,
+      "Content-Transfer-Encoding: base64",
+      "",
+      content.toString("base64"),
+    );
+  }
+  lines.push(`--${boundary}--`, "");
+  return Buffer.from(lines.join("\r\n"), "utf8");
+}
+
+describe("isRfc822Attachment", () => {
+  it("detects message/rfc822 content type", () => {
+    expect(
+      isRfc822Attachment({ contentType: "message/rfc822", filename: "attachment" }),
+    ).toBe(true);
+  });
+
+  it("detects .eml filename regardless of content type", () => {
+    expect(
+      isRfc822Attachment({ contentType: "application/octet-stream", filename: "Fwd.EML" }),
+    ).toBe(true);
+  });
+
+  it("rejects a plain PDF attachment", () => {
+    expect(
+      isRfc822Attachment({ contentType: "application/pdf", filename: "invoice.pdf" }),
+    ).toBe(false);
+  });
+});
+
+describe("unwrapRfc822", () => {
+  it("extracts an inner PDF attachment with its bytes and inner subject", async () => {
+    const subject = 'חשבונית מס 12345 מאת תן ביס בע"מ';
+    const pdfBytes = Buffer.from("%PDF-1.4 fake invoice body", "utf8");
+    const eml = buildEml({
+      subject,
+      html: "<html><body>מצורפת חשבונית</body></html>",
+      attachment: {
+        filename: "invoice.pdf",
+        contentType: "application/pdf",
+        content: pdfBytes,
+      },
+    });
+
+    const result = await unwrapRfc822(eml);
+
+    expect(result.subject).toBe(subject);
+    expect(result.pdfFiles).toHaveLength(1);
+    expect(result.pdfFiles[0].fileName).toBe("invoice.pdf");
+    expect(result.pdfFiles[0].buffer.equals(pdfBytes)).toBe(true);
+  });
+
+  it("returns the inner HTML body (for link extraction) when there is no attachment", async () => {
+    const link = "https://invoice-one.com/view/abc.pdf?sig=xyz";
+    const eml = buildEml({
+      subject: "FW: חשבונית",
+      html: `<html><body>צפה בחשבונית: <a href="${link}">כאן</a></body></html>`,
+    });
+
+    const result = await unwrapRfc822(eml);
+
+    expect(result.pdfFiles).toHaveLength(0);
+    expect(result.html).toContain(link);
+  });
+
+  it("recurses one level into a nested forwarded email to find the PDF", async () => {
+    const pdfBytes = Buffer.from("%PDF-1.4 nested invoice", "utf8");
+    const inner = buildEml({
+      subject: "חשבונית מקורית",
+      html: "<html><body>חשבונית</body></html>",
+      attachment: {
+        filename: "nested.pdf",
+        contentType: "application/pdf",
+        content: pdfBytes,
+      },
+    });
+    const outer = buildEml({
+      subject: "FW: העברה",
+      html: "<html><body>מעביר אליך</body></html>",
+      attachment: {
+        filename: "forwarded.eml",
+        contentType: "message/rfc822",
+        content: inner,
+      },
+    });
+
+    const result = await unwrapRfc822(outer);
+
+    expect(result.pdfFiles).toHaveLength(1);
+    expect(result.pdfFiles[0].fileName).toBe("nested.pdf");
+    expect(result.pdfFiles[0].buffer.equals(pdfBytes)).toBe(true);
+  });
+});

--- a/src/lib/email/unwrap-rfc822.ts
+++ b/src/lib/email/unwrap-rfc822.ts
@@ -1,0 +1,117 @@
+/**
+ * Unwrap "Forward as attachment" emails (message/rfc822).
+ *
+ * Outlook's "Forward as attachment" wraps each original email as a
+ * `message/rfc822` attachment instead of carrying the original PDF/link
+ * directly. The inbound pipeline only accepts `application/pdf` (+Excel)
+ * attachments, so these wrapped emails were silently filtered to zero and
+ * logged as "no attachments / no download links".
+ *
+ * Real incident 2026-06-15: hadas@latableg.com forwarded 3 March Tenbis
+ * commission invoices as message/rfc822 attachments — all three were dropped
+ * (`raw_attachment_count=3`, `filtered_attachment_count=0`).
+ *
+ * This module parses the wrapped .eml and surfaces what the inbound handler
+ * needs:
+ *  - any PDF/Excel attachments inside (link-less invoices), and
+ *  - the inner HTML/text body so the existing link-download path
+ *    (`extractAndDownloadLinks`) can recover link-based invoices
+ *    (10bis invoice-one.com / Mandrill PDFs), and
+ *  - the inner Subject, so the caller can classify the document correctly
+ *    (the OUTER forward often has an empty subject).
+ */
+import PostalMime from "postal-mime";
+
+const DOCUMENT_EXTENSIONS = [".pdf", ".xlsx", ".xls"] as const;
+const DOCUMENT_MIME_TYPES = new Set([
+  "application/pdf",
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  "application/vnd.ms-excel",
+]);
+
+/** Maximum nesting depth — guards against "forward of a forward of a ...". */
+const MAX_DEPTH = 2;
+
+export interface UnwrappedRfc822 {
+  /** Inner email Subject (used to classify the document type). */
+  subject: string;
+  /** Inner email HTML body (for link extraction). */
+  html: string;
+  /** Inner email plain-text body (for link extraction). */
+  text: string;
+  /** Document attachments (PDF/Excel) found inside the wrapped email. */
+  pdfFiles: { fileName: string; buffer: Buffer }[];
+}
+
+/** True when an inbound attachment is a forwarded email (message/rfc822 / .eml). */
+export function isRfc822Attachment(att: {
+  contentType: string;
+  filename: string;
+}): boolean {
+  return (
+    att.contentType.toLowerCase() === "message/rfc822" ||
+    att.filename.toLowerCase().endsWith(".eml")
+  );
+}
+
+function toBuffer(content: ArrayBuffer | Uint8Array | string): Buffer {
+  if (typeof content === "string") return Buffer.from(content, "base64");
+  return Buffer.from(content as ArrayBuffer);
+}
+
+function isDocumentAttachment(filename: string, mimeType: string): boolean {
+  const lower = filename.toLowerCase();
+  return (
+    DOCUMENT_MIME_TYPES.has(mimeType.toLowerCase()) ||
+    DOCUMENT_EXTENSIONS.some((ext) => lower.endsWith(ext))
+  );
+}
+
+/**
+ * Parse a wrapped email (raw RFC822 bytes) and extract document attachments
+ * plus the inner subject/body. Recurses one level into nested message/rfc822
+ * attachments (defensive — a forward of a forward). A malformed nested
+ * message is skipped rather than failing the whole unwrap.
+ */
+export async function unwrapRfc822(
+  buffer: Buffer,
+  depth = 0,
+): Promise<UnwrappedRfc822> {
+  const email = await PostalMime.parse(buffer, {
+    attachmentEncoding: "arraybuffer",
+  });
+
+  const pdfFiles: { fileName: string; buffer: Buffer }[] = [];
+  let html = email.html ?? "";
+  let text = email.text ?? "";
+
+  for (const att of email.attachments) {
+    const fileName = att.filename ?? "attachment";
+    const mimeType = att.mimeType ?? "";
+    const contentBuffer = toBuffer(att.content);
+
+    // Nested forward-as-attachment: recurse to find the real document.
+    if (
+      depth < MAX_DEPTH &&
+      (mimeType.toLowerCase() === "message/rfc822" ||
+        fileName.toLowerCase().endsWith(".eml"))
+    ) {
+      try {
+        const nested = await unwrapRfc822(contentBuffer, depth + 1);
+        pdfFiles.push(...nested.pdfFiles);
+        html += `\n${nested.html}`;
+        text += `\n${nested.text}`;
+      } catch {
+        // Skip a malformed nested message — the body link scan may still
+        // recover the invoice.
+      }
+      continue;
+    }
+
+    if (isDocumentAttachment(fileName, mimeType)) {
+      pdfFiles.push({ fileName, buffer: contentBuffer });
+    }
+  }
+
+  return { subject: email.subject ?? "", html, text, pdfFiles };
+}


### PR DESCRIPTION
מתקן קליטת מיילים שנשלחו ב"העברה כצרופה" (Outlook **Forward as attachment**).

## הבעיה
ב-15.6 הדס העבירה 3 חשבוניות עמלה של מרץ מתן-ביס בהעברה-כצרופה. כל חשבונית הגיעה כ-`message/rfc822` (מייל-בתוך-מייל), לא כ-PDF. הפייפליין קיבל רק `application/pdf`, אז שלושתם סוננו והמייל נכשל עם "אין קבצים / אין לינקים" (`raw_attachment_count=3`, `filtered_attachment_count=0`). בנוסף הנושא החיצוני ריק → סיווג שגוי כ-`client_report`.

## התיקון
- **`src/lib/email/unwrap-rfc822.ts`** (חדש): מפענח את ה-.eml, מחלץ PDF/Excel פנימיים + גוף פנימי (להורדת לינקים) + נושא פנימי (לסיווג). רקורסיה רמה אחת ל"העברה של העברה".
- **`email-inbound/route.ts`**: מפצל rfc822 מקבצים ישירים, מחלץ, מסווג לפי הנושא הפנימי. ריפקטור ל-`processBufferFile` משותף. תנאי הכשל "אין קבצים" יורה רק אם כלום לא נמצא באף ערוץ.
- **`replay-inbound/route.ts`**: עותק מקביל — מקבל את אותו unwrap כדי ששחזור יעבוד.
- טסטי יחידה ל-`unwrapRfc822`.

## אימות
- `tsc` 0 שגיאות · ESLint נקי · 6 טסטי unwrap חדשים + 83 טסטי email/parsers קיימים עוברים · `npm run build` עובר.

## אחרי מיזוג
שחזור 3 החשבוניות דרך `POST /api/admin/replay-inbound` עם `email_id=24e4d9ea-5a71-46fa-9106-c5a903b2735b` (download_url ב-Resend בתוקף 7 ימים).

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)