### PR TITLE
fix(tenbis-invoice): persist extracted invoice number

### DIFF
--- a/src/lib/client-parsers/invoice-tenbis-parser.ts
+++ b/src/lib/client-parsers/invoice-tenbis-parser.ts
@@ -497,6 +497,7 @@ export async function parseTenbisInvoice(
       success: true,
       data: {
         franchiseeName: franchiseeName || "לא זוהה",
+        invoiceNumber: invoiceNumber || undefined,
         totalAmount: headlineAmount,
         commissionAmount: headlineAmount,
         commissionRate: 0,


### PR DESCRIPTION
Parser extracted invoiceNumber but omitted it from the returned data, so client_document.invoice_number was always NULL for Tenbis commission invoices. Bubble it up (processor already reads data.invoiceNumber). The 3 recovered March invoices were backfilled directly.